### PR TITLE
Fix for broken drag and drop on (multi-)touch screens in Chrome 56+

### DIFF
--- a/styles/mainStyle.css
+++ b/styles/mainStyle.css
@@ -126,6 +126,7 @@ canvas{
 	position: relative;
 	margin: auto auto;
 	opacity: 0.6;
+	touch-action: none;
    width: 100%;
 }
 


### PR DESCRIPTION
Chrome 56 introduced a breaking change that affects certain touch interactions:
https://developers.google.com/web/updates/2017/01/scrolling-intervention

It does not affect anything related to mouse events AFAIK, only touch event related things. So if Chrome (Chromium) is started with
```
chromium-browser --enable-touch --overscroll-history-navigation=0 https://www.matchthenet.de
```
drag and drop doesn't work on most touch screens. This is especially important for multi touch screens (because single touch screens usually just emulate a mouse/touchpad).

I recently tested with Chrome 69 on Ubuntu 18.04. Chrome on mobile (Android) is also affected.

The fix just adds the `touch-action: none;` CSS property to the `.net` CSS class (see the link above for an explanation). If the `.net` class is not the right place to put it, please move the CSS property accordingly.